### PR TITLE
Build Windows+PY35 and remove homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ env:
     - secure: "JhwOVyntXaRvgASiRL+LB3Hyn8SDdsYVOd4LedaFifQDs/nlSYaLkCLkrxgemS6Me45Af5YYo/rUnpkqFYp1UnNPecaI0p83185eh9SVWkSVJcikwcJqv6gXR65BVkulXjhqDpzTN8xLoXPJ+OstVf/gdXEdHX6GFH9+59aKRf4c9HBmeKZg9D1tGttlUx0bctmP+czx+RA9ktLsFF8LNnC2hqwi7Bkoqa932i8kVE3GGu5nvcoz11FOJ0sP9xri92MHyRdOETP7uiDtyjendMP4kTimyTER/Gtbe8wUipfx+dZH/DtzfdEt/8xFGiz1qZjGwf4io0PYUgCWH4aTzobsMf8+KMhPzaJFns/QGGIg3IWEpM7daonMpz6sTXPqiXCezd/wW5AMb78K40XLf+kZpiZz7WdVARdJmduyNs80MODvFRKo3cTOqOuSZO8eAAP/42DwFY77qqliBLlIaD6qDvaWN+Epdv7dWwXsC6+QbeWV2FwcoKvOwUZ3vcXWhLQN3FsMRkq4FpVxCvLoiMJQXQJMrHFlFfJ8CF3jO/jA8079fxUn2d6NtvwywiJvLWVOBkirL/KuUwlJsQlwKe3a/FsdajziEgkiMkju8FJufYNq+FglkdruA8r/yeR67wd6e8JjaeKYxMjLRRj8IvmG7ESQNHJZaFu2ms6Md10="
 
 
-before install:
+before_install:
     - brew remove --force $(brew list)
 
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,20 @@ environment:
       CONDA_NPY: 111
       CONDA_PY: 34
 
+    - TARGET_ARCH: x86
+      CONDA_NPY: 110
+      CONDA_PY: 35
+    - TARGET_ARCH: x64
+      CONDA_NPY: 110
+      CONDA_PY: 35
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 111
+      CONDA_PY: 35
+    - TARGET_ARCH: x64
+      CONDA_NPY: 111
+      CONDA_PY: 35
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,7 @@ source:
     md5: 0cc07d16345ad281ab4e7faf24d40f97
 
 build:
-    number: 1
-    skip: True  # [win and py35]
+    number: 2
     entry_points:
         - rio = rasterio.rio.main:cli
 


### PR DESCRIPTION
Don't skip `Windows`+`Python 3.5` now that `gdal` is available. 