### PR TITLE
Fix and test rasterio 'rio' CLI entry point

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,9 @@ source:
     md5: 0cc07d16345ad281ab4e7faf24d40f97
 
 build:
-    number: 2
+    number: 3
     entry_points:
-        - rio = rasterio.rio.main:cli
+        - rio = rasterio.rio.main:main_group
 
 requirements:
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ requirements:
 test:
     imports:
         - rasterio
+    commands:
+        - rio --help
 
 about:
     home: https://github.com/mapbox/rasterio
@@ -41,3 +43,4 @@ about:
 extra:
     recipe-maintainers:
         - ocefpaf
+        - ceholden

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,7 +1,5 @@
-import click.testing
 import numpy
 import rasterio
-from rasterio.rio.main import main_group
 from rasterio.features import rasterize
 from rasterio.transform import IDENTITY
 
@@ -24,10 +22,3 @@ with rasterio.drivers():
             transform=IDENTITY,
             crs={'init': "EPSG:4326"}) as out:
         out.write_band(1, result.astype(numpy.uint8))
-
-
-# Test CLI
-runner = click.testing.CliRunner()
-result = runner.invoke(main_group, ['--version'])
-assert result.exit_code == 0
-assert rasterio.__version__ in result.output

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,5 +1,7 @@
+import click.testing
 import numpy
 import rasterio
+from rasterio.rio.main import main_group
 from rasterio.features import rasterize
 from rasterio.transform import IDENTITY
 
@@ -22,3 +24,10 @@ with rasterio.drivers():
             transform=IDENTITY,
             crs={'init': "EPSG:4326"}) as out:
         out.write_band(1, result.astype(numpy.uint8))
+
+
+# Test CLI
+runner = click.testing.CliRunner()
+result = runner.invoke(main_group, ['--version'])
+assert result.exit_code == 0
+assert rasterio.__version__ in result.output


### PR DESCRIPTION
The `rasterio` recipe has an out-of-date entry point definition for the rasterio command line interface. When calling `rio`:

```
> rio --help
Traceback (most recent call last):
  File "/projectnb/landsat/datasets/DATACUBE/conda/envs/tilezilla/bin/rio", line 4, in <module>
    from rasterio.rio.main import cli
ImportError: cannot import name cli
```

Rasterio switched from rasterio.rio.main:main to rasterio.rio.main:main_group on [May 30, 2015](https://github.com/mapbox/rasterio/commit/f738f1cd477b1dead4d2988575f205ada869c80d). I've fixed the reference in `recipe/meta.yaml` and added a small test in `recipe/run_test.py` to ensure the rasterio CLI can at least get to the `rio --version` option.

This is my first PR to conda-forge so please let me know if I can improve anything. Thanks very much for maintaining these builds!