### PR TITLE
Bump to 0.35.0.post1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,10 @@ env:
 
 
 before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -91,6 +91,10 @@ install:
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    # Workaround for Python 3.4 and x64 bug in latest conda-build.
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.34.0" %}
+{% set version = "0.35.0.post1" %}
 
 package:
     name: rasterio
@@ -6,11 +6,11 @@ package:
 
 source:
     fn: rasterio-{{ version }}.tar.gz
-    url: https://pypi.python.org/packages/source/r/rasterio/rasterio-{{ version }}.tar.gz
-    md5: 203c1336e94900b3b98f31cb3f011c18
+    url: https://github.com/mapbox/rasterio/archive/{{ version }}.tar.gz
+    sha256: c078b1d0950be212607918d67234d4134e392ecf09615525825ec25f6a16989f
 
 build:
-    number: 1
+    number: 0
     entry_points:
         - rio = rasterio.rio.main:main_group
 
@@ -19,8 +19,9 @@ requirements:
         - python
         - numpy x.x
         - cython
-        - gdal 1.11.4
         - setuptools
+        # Rasterio **does** work with gdal, this is just b/c rasterio is usually installed along side fiona.
+        - gdal 1.11.4
     run:
         - python
         - affine

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -3,6 +3,15 @@ import rasterio
 from rasterio.features import rasterize
 from rasterio.transform import IDENTITY
 
+# Set GDAL_DATA. This is done normally done by the activate script,
+# but this doesn't happen in the testing (_test) environment.
+import os
+if 'LIBRARY_PREFIX' in os.environ:
+    # Windows.
+    gdalData = os.path.join(os.environ['LIBRARY_PREFIX'], 'share', 'gdal')
+else:
+    # Linux/OS X.
+    gdalData = os.path.join(os.environ['PREFIX'], 'share', 'gdal')
 
 rows = cols = 10
 geometry = {'type': 'Polygon',


### PR DESCRIPTION
Changes
=======

0.35.0.post1 (2016-05-04)
-------------------------
- Bug fix: added rasterfill.cpp to MANIFEST.in so it is included in source
  distributions no matter the build system's GDAL version (#690).

0.35.0 (2016-05-04)
-------------------
- Requirements: affine requirement upped to >=1.3.0 (#430).
- Bug fix: passing an empty JSON object to `crs.from_string()` raises CRSError
  instead of passing silently (#628, #642).
- Bug fix: GDAL errors are no longer written to stderr; we no longer undefine
  error handlers (#649, #658).
- Bug fix: the Rasterio library only configures a NullHandler, applications
  must configure their own handlers to see Rasterio's log messages (#649,
  #658).
- Bug fix: AWS credentials are only sought by Rasterio when s3:// URLs are
  passed to `rasterio.open()` (#650, #665).
- Bug fix: window comparison functions now raise a ValueError when windows do
  not intersect instead of returning an empty sequence (#651, #656, #662).
- Bug fix: upgrade from deprecated Numpy usage in `read()` by explicitly
  converting window offsets to ints (#678, #680).
- Refactoring: window comparison functions may now take a variable number of
  windows as positional arguments in addition to a sequence of windows.
- Refactoring: logging is much finer grained now because we've changed to the
  `logger = logging.getLogger(__name__)` pattern throughout Rasterio (#649,
  #658).
- Refactoring: replaced old `drivers()` implementation with a new `Env` class
  and more consistent usage of it through the library and command line
  interface (#665, #682).