### PR TITLE
rerender

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
-      conda config --set show_channel_urls true
       conda update --yes conda
       conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
+      conda config --set show_channel_urls true
       
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -91,9 +91,9 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels conda-forge
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
     # Workaround for Python 3.4 and x64 bug in latest conda-build.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.35.1" %}
+{% set version = "0.36.0" %}
 
 package:
     name: rasterio
@@ -7,10 +7,10 @@ package:
 source:
     fn: rasterio-{{ version }}.tar.gz
     url: https://github.com/mapbox/rasterio/archive/{{ version }}.tar.gz
-    sha256: 2e4b94de3cf92f5d81de6d1265b45afd9ac3085b158dcfcaec47c39cfa66029a
+    sha256: 292d583dec745792242846081abc8c3a97a606af78f9fa3f655467b5b60a348a
 
 build:
-    number: 1
+    number: 0
     entry_points:
         - rio = rasterio.rio.main:main_group
 
@@ -20,8 +20,7 @@ requirements:
         - numpy x.x
         - cython
         - setuptools
-        # Rasterio **does** work with gdal, this is just b/c rasterio is usually installed along side fiona.
-        - gdal 1.11.4
+        - gdal >=2.*
     run:
         - python
         - affine
@@ -29,7 +28,7 @@ requirements:
         - enum34  # [py27]
         - numpy x.x
         - snuggs
-        - gdal 1.11.4
+        - gdal >=2.*
         - click-plugins
 
 test:
@@ -37,7 +36,6 @@ test:
         - rasterio
     commands:
         - rio --help
-        - conda inspect linkages -n _test rasterio  # [linux]
 
 about:
     home: https://github.com/mapbox/rasterio


### PR DESCRIPTION
Using `gdal 2.x`.

```
Changes
=======

0.36.0 (2016-06-14)
-------------------

Bug fixes:

- rio-merge now copies colormaps to output files (#774, #778).
- The correct `--force-overwrite` and `--output` usage is now provided in the
  case of a `FileOverwriteError` (#750).
- Passing undefined CRS to `reproject` no longer causes a segfault (#749).
- GDAL's invert projection check is always used by default in reprojecting
  (#780).
- Forward slashes are always used for GDAL VSI paths (`/vsizip/` etc) instead
  of `os.path.sep` (#754, #789).

Documentation:

- Contributing guidelines have been added (#701).
- Axis order has been corrected in image processing doc (#700).
- A framework for comprehensive documentaton has been created (#713, #723,
  #729, #737, #738, #739, #740, #748, #756, #760).

New features:

- `--src-nodata` and `--dst-nodata` options for rio-warp (#746).
- `read()` and `read_masks()` take an `out_shape` argument for decimated reads
  (#761).
- Color interpretation of bands added to rio-info output (#766).
- Dataset objects have a new per-dataset mask property: `dataset_mask` (#716).
- Utility functions for rehaping and plotting arrays have been added to
  `rasterio.plot` (#718, #765).
- New `CRS` class like our old crs dicts, but with methods attached (#736,
  #770).

Packaging:

- setup.py has new install extras: '[plot]', and '[all]' (#744).

Refactoring:

- We've standardized on `import numpy as np` (#727, #738, #740) throughout the
  project.
- The `five` module has been renamed to `compat` (#745).

Testing:

- More coverage, more xfailing tests to mark known bugs (#742, #762, #753,
  #773, #782).
```
PS: Re-rendered with https://github.com/conda-forge/conda-smithy/pull/199