### PR TITLE
Pin gdal 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
       conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
-      conda config --set show_channel_urls true
       
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -91,9 +91,9 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels conda-forge
-    - cmd: conda config --set show_channel_urls true
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
     # Workaround for Python 3.4 and x64 bug in latest conda-build.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 292d583dec745792242846081abc8c3a97a606af78f9fa3f655467b5b60a348a
 
 build:
-    number: 0
+    number: 1
     entry_points:
         - rio = rasterio.rio.main:main_group
 
@@ -20,7 +20,7 @@ requirements:
         - numpy x.x
         - cython
         - setuptools
-        - gdal >=2.*
+        - gdal 2.1.*
     run:
         - python
         - affine
@@ -28,7 +28,7 @@ requirements:
         - enum34  # [py27]
         - numpy x.x
         - snuggs
-        - gdal >=2.*
+        - gdal 2.1.*
         - click-plugins
 
 test:


### PR DESCRIPTION
Prevents from wrongly downloading `gdal` from the default channel.