### PR TITLE
Add inspect linkages test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ test:
         - rasterio
     commands:
         - rio --help
+        - conda inspect linkages -n _test rasterio  # [linux]
 
 about:
     home: https://github.com/mapbox/rasterio


### PR DESCRIPTION
Ideally we should always run this test when there is a `cython` extension.