### PR TITLE
Rebuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ conda search rasterio --channel conda-forge
 ```
 
 
-
 About conda-forge
 =================
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
@@ -14,6 +12,8 @@ environment:
   # We set a default Python version for the miniconda that is to be installed. This can be
   # overridden in the matrix definition where appropriate.
   CONDA_PY: "27"
+  CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
+
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -22,50 +22,62 @@ environment:
     - TARGET_ARCH: x86
       CONDA_NPY: 110
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_NPY: 110
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_NPY: 111
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_NPY: 110
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_NPY: 110
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_NPY: 111
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_NPY: 110
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_NPY: 110
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
     - TARGET_ARCH: x86
       CONDA_NPY: 111
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -86,24 +98,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,8 @@ test:
     - rio --help
     - rio info $RECIPE_DIR/test_data/test.tif  # [not win]
     - rio info %RECIPE_DIR%\test_data\test.tif  # [win]
-    - conda inspect linkages -p $PREFIX rasterio  # [not win]
-    - conda inspect objects -p $PREFIX rasterio  # [osx]
+    #- conda inspect linkages -p $PREFIX rasterio  # [not win]
+    #- conda inspect objects -p $PREFIX rasterio  # [osx]
 
 about:
   home: https://github.com/mapbox/rasterio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 03fc123ef4ede2017b79e8a26c9ba374a10e116e05a359121bbf696307642ca6
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - rio = rasterio.rio.main:main_group
 
@@ -42,8 +42,8 @@ test:
     - rio --help
     - rio info $RECIPE_DIR/test_data/test.tif  # [not win]
     - rio info %RECIPE_DIR%\test_data\test.tif  # [win]
-    #- conda inspect linkages -p $PREFIX rasterio  # [not win]
-    #- conda inspect objects -p $PREFIX rasterio  # [osx]
+    - conda inspect linkages -p $PREFIX rasterio  # [not win]
+    - conda inspect objects -p $PREFIX rasterio  # [osx]
 
 about:
   home: https://github.com/mapbox/rasterio


### PR DESCRIPTION
Every time `gdal`'s dependencies change we need to re-build `rasterio` because it links to everything `gdal` brings with it. In this case we changed the `geos` version.