### PR TITLE
Update to 1.0a3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0a2" %}
+{% set version = "1.0a3" %}
 
 package:
   name: rasterio
@@ -7,10 +7,10 @@ package:
 source:
   fn: rasterio-{{ version }}.tar.gz
   url: https://github.com/mapbox/rasterio/archive/{{ version }}.tar.gz
-  sha256: 03fc123ef4ede2017b79e8a26c9ba374a10e116e05a359121bbf696307642ca6
+  sha256: e55987343c017390a1478668b5362c38078ff593c8584ed49eb118e4f605f871
 
 build:
-  number: 1
+  number: 0
   entry_points:
     - rio = rasterio.rio.main:main_group
 


### PR DESCRIPTION
1.0a3 (2016-10-31)
------------------

New features:

- The `DatasetBase` class is now surfaced in `rasterio.io`. This is not too
  promote the practice of subclassing `DatasetBase` but to help users that
  would like to use type annotations (\#925) or make `isinstance()` assertions.
- Ground control points may be read from and written to datasets (when the
  format permits) and may be used when reprojecting arrays with `reproject()`
  or on the command line with rio-warp (\#203, \#916). A new rio-gcps command
  has been added, it can print a dataset's GCPs as GeoJSON Feature sequences
  or FeatureCollections.
- A `BytesIO` like `MemoryFile` class has been added for an improved Python
  interface to GDAL's in-memory filesystem (\#899, \#925).
- Error handlers are pushed to GDAL on entering a GDAL environment and popped
  when exiting (\#876, \#902, \#907).
- The GIL is released when calling GDAL's ChunkAndWarp() (\#912).

Bug fixes:

- transform_geom() would fail when encountering geometries with z coordinate
  values, but now handles them properly (\#922, \#923).
- show_hist() failed when nans were present in data (\#913) and this has been
  fixed with the use of nanmin() and nanmax() in \#914.