### PR TITLE
Update to rasterio 1.0a8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0a7" %}
+{% set version = "1.0a8" %}
 
 package:
   name: rasterio
@@ -7,7 +7,7 @@ package:
 source:
   fn: rasterio-{{ version }}.tar.gz
   url: https://github.com/mapbox/rasterio/archive/{{ version }}.tar.gz
-  sha256: 472908e335fc9a4d072fb6f41e08b58eb7120f18f6c12e28ffd3beb86edd7e1f
+  sha256: 20c1993ecdda39f614a2d59d7d6040291b78876b84bcb870c5e9d89d0394ab75
 
 build:
   number: 0


### PR DESCRIPTION
Update to rasterio 1.0a8 mapbox/rasterio#1004

Changes:
```
1.0a8 (2017-03-29)
------------------

Bug fixes:

- Secrets kept in GDAL config options could have been leaked via the Python
  logger. AWS keys and tokens have always been redacted, but other options like
  GDAL_HTTP_USERPWD were not. Logging of GDAL config options has been removed.
- Use of Rasterio with Python threads has not been well tested in
  previous versions and a bug (#986) involving shared GDAL environment
  state was found. Rasterio now uses thread local variables to track
  GDAL environment state and uses the appropriate GDAL API functions to
  isolate the environments of child threads from each other while
  permitting inheritance from the main Python thread (#993, #996, #997).
  Tests using both `ThreadPoolExecutor` and `ProcessPoolExecutor` have
  been added to guard against regresion.
```