### PR TITLE
Update to 1.0a9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,6 @@
 
 environment:
 
-  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-  # /E:ON and /V:ON options are not enabled in the batch script intepreter
-  # See: http://stackoverflow.com/a/13751649/163740
-  CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
-
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -45,14 +40,34 @@ environment:
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
     - TARGET_ARCH: x86
+      CONDA_NPY: 112
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 112
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
       CONDA_NPY: 111
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 112
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 112
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -63,7 +78,7 @@ platform:
 install:
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
-        curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py > ff_ci_pr_build.py
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
         ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
         del ff_ci_pr_build.py
 
@@ -83,7 +98,6 @@ install:
     - cmd: conda config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
@@ -91,6 +105,6 @@ install:
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build recipe --quiet"
+    - conda build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,16 +24,30 @@ show_channel_urls: true
 CONDARC
 )
 
+# In order for the conda-build process in the container to write to the mounted
+# volumes, we need to run with the same id as the host machine, which is
+# normally the owner of the mounted volumes, or at least has write permission
+HOST_USER_ID=$(id -u)
+# Check if docker-machine is being used (normally on OSX) and get the uid from
+# the VM
+if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
+    HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
+fi
+
 rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
 
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
+                        -e HOST_USER_ID="${HOST_USER_ID}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit 1
 
+set -e
+set +x
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
+set -x
 export PYTHONUNBUFFERED=1
 
 echo "$config" > ~/.condarc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0a8" %}
+{% set version = "1.0a9" %}
 
 package:
   name: rasterio
@@ -7,7 +7,7 @@ package:
 source:
   fn: rasterio-{{ version }}.tar.gz
   url: https://github.com/mapbox/rasterio/archive/{{ version }}.tar.gz
-  sha256: 20c1993ecdda39f614a2d59d7d6040291b78876b84bcb870c5e9d89d0394ab75
+  sha256: bbb635576d8d59d364a6dd3eb2413b375be4f140194dc43e2f120a7f0907111c
 
 build:
   number: 0
@@ -20,7 +20,7 @@ requirements:
     - numpy x.x
     - cython
     - setuptools
-    - gdal 2.1.*
+    - gdal 2.2.*
   run:
     - python
     - setuptools
@@ -30,7 +30,7 @@ requirements:
     - enum34  # [py27]
     - numpy x.x
     - snuggs >=1.2
-    - gdal 2.1.*
+    - gdal 2.2.*
     - click-plugins
 
 test:


### PR DESCRIPTION
```
1.0a9 (2017-06-02)
------------------

Breaking changes:

- Removed `**options` argument from `rasterio.warp.transform()`.  Transformer
  options should be set explicitly inside the currently active
  `rasterio.env.Env()`(#1010).  This argument was initially added in `1.0a1`.
- The function `transform_geom()` now always splits geometries at the anti-
  meridian (#1024).
- The `crs` property of a dataset is now `None` instead of `CRS()` when the
  dataset's coordinate reference system is undefined (#1057).

New features:

- Enable setting and getting `GDAL_CACHEMAX` (#1042).
- Integer config option values are now properly encoded and decoded (#1042).
- A `from_wkt()` CRS constructor has been added (#1070).
- Targeting aligned pixels in rio-warp (#941).
- A new `WarpedVRT` class that surfaces GDAL's warp-on-demand VRT features. No
  XML editing is required (#1071, #1029).

Bug fixes:

- `dtypes.get_minimum_dtype()` now returns proper value for uint* types
  (#1064).
- Rasterio now uses `OSRRelease()` to avoid destroying shared spatial 
  reference system objects (#1031).
- GDAL_SKIP and GDAL_DRIVER_PATH options, when needed, are now set before
  driver registration (#1001).
- A failure of reprojection to an array when source dataset bands have an
  index higher than 1 has been fixed (#1056).
```