### PR TITLE
Pin gdal 2.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,9 @@ osx_image: xcode6.4
 env:
   matrix:
     
-    - CONDA_NPY=111  CONDA_PY=27
-    - CONDA_NPY=112  CONDA_PY=27
-    - CONDA_NPY=113  CONDA_PY=27
-    - CONDA_NPY=111  CONDA_PY=35
-    - CONDA_NPY=112  CONDA_PY=35
-    - CONDA_NPY=113  CONDA_PY=35
-    - CONDA_NPY=111  CONDA_PY=36
-    - CONDA_NPY=112  CONDA_PY=36
-    - CONDA_NPY=113  CONDA_PY=36
+    - CONDA_PY=27
+    - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "JhwOVyntXaRvgASiRL+LB3Hyn8SDdsYVOd4LedaFifQDs/nlSYaLkCLkrxgemS6Me45Af5YYo/rUnpkqFYp1UnNPecaI0p83185eh9SVWkSVJcikwcJqv6gXR65BVkulXjhqDpzTN8xLoXPJ+OstVf/gdXEdHX6GFH9+59aKRf4c9HBmeKZg9D1tGttlUx0bctmP+czx+RA9ktLsFF8LNnC2hqwi7Bkoqa932i8kVE3GGu5nvcoz11FOJ0sP9xri92MHyRdOETP7uiDtyjendMP4kTimyTER/Gtbe8wUipfx+dZH/DtzfdEt/8xFGiz1qZjGwf4io0PYUgCWH4aTzobsMf8+KMhPzaJFns/QGGIg3IWEpM7daonMpz6sTXPqiXCezd/wW5AMb78K40XLf+kZpiZz7WdVARdJmduyNs80MODvFRKo3cTOqOuSZO8eAAP/42DwFY77qqliBLlIaD6qDvaWN+Epdv7dWwXsC6+QbeWV2FwcoKvOwUZ3vcXWhLQN3FsMRkq4FpVxCvLoiMJQXQJMrHFlFfJ8CF3jO/jA8079fxUn2d6NtvwywiJvLWVOBkirL/KuUwlJsQlwKe3a/FsdajziEgkiMkju8FJufYNq+FglkdruA8r/yeR67wd6e8JjaeKYxMjLRRj8IvmG7ESQNHJZaFu2ms6Md10="

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,92 +10,26 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
-      CONDA_NPY: 111
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
-      CONDA_NPY: 111
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
-      CONDA_NPY: 112
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 112
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 113
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 113
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 111
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
-      CONDA_NPY: 111
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
     - TARGET_ARCH: x86
-      CONDA_NPY: 112
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 112
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 113
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 113
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 111
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda36
 
     - TARGET_ARCH: x64
-      CONDA_NPY: 111
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 112
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 112
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 113
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 113
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -57,65 +57,20 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 9 case(s).
+# Embarking on 3 case(s).
     set -x
-    export CONDA_NPY=111
     export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_NPY=112
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=113
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=111
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_NPY=112
-    export CONDA_PY=35
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=113
-    export CONDA_PY=35
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=111
-    export CONDA_PY=36
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=112
-    export CONDA_PY=36
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=113
     export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,27 +10,31 @@ source:
   sha256: bbb635576d8d59d364a6dd3eb2413b375be4f140194dc43e2f120a7f0907111c
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - rio = rasterio.rio.main:main_group
 
 requirements:
   build:
     - python
-    - numpy x.x
-    - cython
     - setuptools
-    - gdal 2.2.*
+    - cython
+    - numpy 1.7.*  # [py27]
+    - numpy 1.9.*  # [py35]
+    - numpy 1.11.*  # [py36]
+    - libgdal 2.1.*
   run:
     - python
     - setuptools
+    - numpy >=1.7  # [py27]
+    - numpy >=1.9  # [py35]
+    - numpy >=1.11  # [py36]
     - affine >=1.3.0
     - boto3 >=1.2.4
     - cligj
     - enum34  # [py27]
-    - numpy x.x
     - snuggs >=1.2
-    - gdal 2.2.*
+    - libgdal 2.1.*
     - click-plugins
 
 test:


### PR DESCRIPTION
Unfortunately `fiona` is not compatible with `gdal 2.2.*` yet, so we need to pin everything to `2.1.*` is we want to install them along side with `fiona`. Note that installing the previous build number with latest `gdal` is still possible when not installing `fiona`.

(I also updated the pinning and I am trying to build with xorg instead of relying on `yum` requirements.)