### PR TITLE
fix deps

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: bbb635576d8d59d364a6dd3eb2413b375be4f140194dc43e2f120a7f0907111c
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - rio = rasterio.rio.main:main_group
 
@@ -19,21 +19,20 @@ requirements:
     - python
     - setuptools
     - cython
-    - numpy 1.7.*  # [py27]
-    - numpy 1.9.*  # [py35]
+    - numpy 1.9.*  # [py27 or py35]
     - numpy 1.11.*  # [py36]
     - libgdal 2.1.*
   run:
     - python
     - setuptools
-    - numpy >=1.7  # [py27]
-    - numpy >=1.9  # [py35]
+    - numpy >=1.9  # [py27 or py35]
     - numpy >=1.11  # [py36]
     - affine >=1.3.0
+    - attrs
     - boto3 >=1.2.4
     - cligj
     - enum34  # [py27]
-    - snuggs >=1.2
+    - snuggs >=1.4.1
     - libgdal 2.1.*
     - click-plugins
 


### PR DESCRIPTION
The `setup.py` is different from the `requirements.txt` file. This should cover the actual dependencies needed for `rasterio`.