### PR TITLE
Move to dev channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,4 @@ install:
 script:
   - conda build ./recipe
 
-  - upload_or_check_non_existence ./recipe conda-forge --channel=main
+  - upload_or_check_non_existence ./recipe conda-forge --channel=dev

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,4 +71,4 @@ build: off
 test_script:
     - conda build recipe --quiet
 deploy_script:
-    - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main
+    - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=dev

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -62,19 +62,19 @@ source run_conda_forge_build_setup
     export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=dev || exit 1
 
     set -x
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=dev || exit 1
 
     set -x
     export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=dev || exit 1
 touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,6 @@ travis:
 appveyor:
   secure:
     BINSTAR_TOKEN: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
+channels:
+  targets:
+    - [conda-forge, dev]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,12 +5,11 @@ package:
   version: {{ version }}
 
 source:
-  fn: rasterio-{{ version }}.tar.gz
-  url: https://github.com/mapbox/rasterio/archive/{{ version }}.tar.gz
-  sha256: bbb635576d8d59d364a6dd3eb2413b375be4f140194dc43e2f120a7f0907111c
+  url: https://pypi.io/packages/source/r/rasterio/rasterio-{{ version }}.tar.gz
+  sha256: dd91520d55f4238f71ebeadf0ff2e8f23021ca4ff2ff9826ae2cbdf90b109d55
 
 build:
-  number: 2
+  number: 0
   entry_points:
     - rio = rasterio.rio.main:main_group
 
@@ -19,14 +18,14 @@ requirements:
     - python
     - setuptools
     - cython
-    - numpy 1.9.*  # [py27 or py35]
-    - numpy 1.11.*  # [py36]
+    - numpy 1.9.*  # [not (win and py36)]
+    - numpy 1.11.*  # [win and py36]
     - libgdal 2.1.*
   run:
     - python
     - setuptools
-    - numpy >=1.9  # [py27 or py35]
-    - numpy >=1.11  # [py36]
+    - numpy >=1.9  # [not (win and py36)]
+    - numpy >=1.11  # [win and py36]
     - affine >=1.3.0
     - attrs
     - boto3 >=1.2.4


### PR DESCRIPTION
Even though most people are using `rasterio 1.x` as the stable version for a long while it has not been released yet and some old packages that still uses the old syntax and are not pinning to `rasterio 0.*` are broken :-(

We can only hope for an official release soon. Meanwhile I am moving this to the dev channel. (I am also removing the alpha versions from the `main` channel.)