### PR TITLE
Use GDAL 2.2.*

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 33bb76ca13d3fa177ac0ffebad6522c514a38d2b5d55b6db9997c8d1e7ec864a
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - rio = rasterio.rio.main:main_group
 
@@ -20,7 +20,7 @@ requirements:
     - cython
     - numpy 1.9.*  # [not (win and py36)]
     - numpy 1.11.*  # [win and py36]
-    - libgdal 2.1.*
+    - libgdal 2.2.*
   run:
     - python
     - setuptools
@@ -32,7 +32,7 @@ requirements:
     - cligj
     - enum34  # [py27]
     - snuggs >=1.4.1
-    - libgdal 2.1.*
+    - libgdal 2.2.*
     - click-plugins
 
 test:


### PR DESCRIPTION
Version 2.2 has been considered stable for a while and is available through conda-forge. It'd be great to make use of it.