### PR TITLE
Support GDAL 2.1.*

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 47d460326e04c64590ff56952271a184a6307f814efc34fb319c12e690585f3c
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - rio = rasterio.rio.main:main_group
 
@@ -20,7 +20,7 @@ requirements:
     - cython
     - numpy 1.9.*  # [not (win and py36)]
     - numpy 1.11.*  # [win and py36]
-    - gdal 2.2.*
+    - gdal 2.1.*
   run:
     - python
     - setuptools
@@ -32,7 +32,7 @@ requirements:
     - cligj
     - enum34  # [py27]
     - snuggs >=1.4.1
-    - gdal 2.2.*
+    - gdal 2.1.*
     - click-plugins
 
 test:


### PR DESCRIPTION
So long as `fiona` is restricted to `2.1.*`, it is nice to have the most recent rasterio versions available with GDAL `2.1.*` as well.