### PR TITLE
update to 1.0b3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0b2" %}
+{% set version = "1.0b3" %}
 
 package:
   name: rasterio
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/r/rasterio/rasterio-{{ version }}.tar.gz
-  sha256: 32ee19db129871686ffe71c9537adde8dd6c21fe95690654554bd6bead5ed771
+  sha256: d1cd09ebd4e8d89a24e27208e257177d6f80c2faac40d2719cfe2516d8fac17c
 
 build:
   number: 0


### PR DESCRIPTION
```
1.0b3 (2018-06-21)
------------------

Bug fixes:

- The warp memory limit configuration available in gdalwarp has been added
  to `reproject()` and `WarpedVRT`.
- Avoid boundless reads when sampling pixels outside a dataset's extent
  (#1249).
- The logic behind rio-warp's --target-aligned-pixels has been factored into
  a new `aligned_target()` function in the warp module to help resolve 
  #853.
- A regression in the VSI path of some zip:// URLs has been fixed (#1377).
- Transform, coordinate reference system, and ground control points are
  properly set when opening a dataset in w+ mode (#1359.
```