### PR TITLE
Bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 480a9854b59cd4fcf0e1a43aaee9a433cd7db02fd75a61caade5064028b1593b
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and py27]
   entry_points:
     - rio = rasterio.rio.main:main_group


### PR DESCRIPTION
Need to pick up more recent versions of gdal (2.2.4 on Py27-Windows, 2.3.x on everything else)

See https://github.com/conda-forge/gdal-feedstock/issues/244 for more info. This may require waiting on @ocefpaf's work with fixing the pinnings for vc9 to make a valid Windows Python 2.7 package so that that environment uses gdal 2.2.4 instead of 2.3.x.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
