### PR TITLE
GDAL 3.4 without cross-compile

### DIFF
--- a/.ci_support/linux_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.7.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.18'
 pin_run_as_build:

--- a/.ci_support/linux_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.8.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.18'
 pin_run_as_build:

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18python3.7.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.18'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18python3.8.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.18'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.9.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21python3.10.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18python3.7.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.18'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18python3.8.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.18'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.19python3.9.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.21python3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/migrations/gdal34.yaml
+++ b/.ci_support/migrations/gdal34.yaml
@@ -1,0 +1,9 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+gdal:
+- '3.4'
+libgdal:
+- '3.4'
+migrator_ts: 1636499972.7301745

--- a/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 libgdal:
-- '3.3'
+- '3.4'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 libgdal:
-- '3.3'
+- '3.4'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 libgdal:
-- '3.3'
+- '3.4'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 libgdal:
-- '3.3'
+- '3.4'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_arm64_numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.19python3.8.____cpython.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 libgdal:
-- '3.3'
+- '3.4'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.19python3.9.____cpython.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 libgdal:
-- '3.3'
+- '3.4'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 libgdal:
-- '3.3'
+- '3.4'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/win_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.18python3.7.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - vs2017
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.18'
 pin_run_as_build:

--- a/.ci_support/win_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.18python3.8.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - vs2017
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.18'
 pin_run_as_build:

--- a/.ci_support/win_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.19python3.9.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - vs2017
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/win_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.21python3.10.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - vs2017
 libgdal:
-- '3.3'
+- '3.4'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: f9df8548e8a053d5db6057a4fd28d940d98a06d249f8af9e8fde1d8e9587d0b5
 
 build:
-  number: 2
+  number: 3
   entry_points:
     - rio = rasterio.rio.main:main_group
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

The cross compile here likely avoids the crash found on ppc64le with #231.  Perhaps the issue is that GDAL itself has problems there? conda-forge/gdal-feedstock#580

Can revisit this later as more work is done, but we need this green to break a dependency logjam again.