### PR TITLE
enable test_read_compdcs test

### DIFF
--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -60,7 +60,7 @@ if /i "%CI%" == "github_actions" (
     set "TEMP=%RUNNER_TEMP%"
 )
 if /i "%CI%" == "azure" (
-    set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME%"
+    set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
     set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
     if /i "%BUILD_REASON%" == "PullRequest" (
         set "IS_PR_BUILD=True"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [py<38]
-  number: 2
+  number: 3
   entry_points:
     - rio = rasterio.rio.main:main_group
 
@@ -74,7 +74,6 @@ test:
     {% set tests_to_skip = tests_to_skip + " or test_reproject_nodata" %}
     {% set tests_to_skip = tests_to_skip + " or test_reproject_nodata_nan" %}
     {% set tests_to_skip = tests_to_skip + " or test_reproject_dst_nodata_default" %}
-    {% set tests_to_skip = tests_to_skip + " or test_read_compdcs" %}
     - $PYTHON -m pytest -v -m "not wheel" -rxXs -k "not ({{ tests_to_skip }})" tests  # [linux and build_platform == target_platform]
     - $PYTHON -m pytest -v -m "not wheel" -rxXs -k "not ({{ tests_to_skip }})" tests  # [osx]
     - python -m pytest -v -m "not wheel" -rxXs -k "not (test_search_gdal_data_debian or test_decimated_no_use_overview or test_copyfiles_same_dataset_another_name or {{ tests_to_skip }})" tests  # [win]


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I have a suspicion on why the `test_read_compdcs` was segfaulting.  So lets try enabling it again.