### PR TITLE
depend on libgdal-core and not gdal for #303

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -18,7 +18,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
@@ -18,7 +18,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '17'
-gdal:
+libgdal_core:
 - '3.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '17'
-gdal:
+libgdal_core:
 - '3.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '17'
-gdal:
+libgdal_core:
 - '3.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -18,7 +18,7 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '17'
-gdal:
+libgdal_core:
 - '3.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '17'
-gdal:
+libgdal_core:
 - '3.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '17'
-gdal:
+libgdal_core:
 - '3.9'
 macos_machine:
 - arm64-apple-darwin20.0.0

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '17'
-gdal:
+libgdal_core:
 - '3.9'
 macos_machine:
 - arm64-apple-darwin20.0.0

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '17'
-gdal:
+libgdal_core:
 - '3.9'
 macos_machine:
 - arm64-apple-darwin20.0.0

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -18,7 +18,7 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '17'
-gdal:
+libgdal_core:
 - '3.9'
 macos_machine:
 - arm64-apple-darwin20.0.0

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -18,7 +18,7 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '17'
-gdal:
+libgdal_core:
 - '3.9'
 macos_machine:
 - arm64-apple-darwin20.0.0

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -8,7 +8,7 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -8,7 +8,7 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -8,7 +8,7 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -8,7 +8,7 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -8,7 +8,7 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
-gdal:
+libgdal_core:
 - '3.9'
 pin_run_as_build:
   python:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2750dc90d84b09fc27e469fb11cc2a972aee8b3a6589233c5859efc52efa0acc
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - rio = rasterio.rio.main:main_group
 
@@ -28,13 +28,13 @@ requirements:
     - pip
     - cython
     - numpy >=1.24
-    - gdal
+    - libgdal-core
     - proj
     - setuptools
   run:
     - python
     - setuptools >=0.9.8
-    - gdal
+    - libgdal-core
     - affine
     - attrs
     - certifi


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Maybe we should have depended on `libgdal-core` and not `gdal` per https://github.com/conda-forge/rasterio-feedstock/issues/303#issuecomment-2377722919

@conda-forge-admin please rerender